### PR TITLE
Reed suggested revision to 07-mapping.adoc

### DIFF
--- a/sources/sections/07-mapping.adoc
+++ b/sources/sections/07-mapping.adoc
@@ -3,23 +3,23 @@
 
 === Semantics
 
-The previous section defined requirements for conformance to this standard, but
+The previous section defined requirements for conformance to the ModSpec, but
 testing for that conformance may depend on how the various forms and parts of a
-candidate conformant standard are viewed. This clause will define how those views
+candidate conformant standard are viewed. This clause specifiess how those views
 are to be defined in most of the common cases. Standards that take an alternative
 mechanism to the ones listed here must be tested solely on the structure of their
-conformance test suite, until an extension to this standard is defined for that
+conformance test suite, until an extension to ModSpec is defined for that
 alternate mechanism.
 
 Standards are often structured about some form of modeling language, or
 implementation paradigm. This clause looks at some common types of models and
 defines a mechanism to map parts of the model (language, schema, etc.) to the
-conformance classes used as the specification model from <<cls-6-1>>.
+conformance classes used as the model from <<cls-6-1>>.
 
 As suggested in Clause <<req-22>>, the structure of the normative clauses in a
 standard should parallel the structure of the conformance requirements classes in
 that standard. The structure of the normative clauses in a well written
-specification will follow the structure of its model; this means that all three are
+standard will follow the structure of its model. This means that all three are
 parallel.
 
 === Data Models
@@ -30,7 +30,7 @@ parallel.
 then that model should belong in the core since it can be considered as part of a
 common reference model and vocabulary.#
 
-If a data mode is to be used to create "data transfer" elements, the issue is more
+If a data model is to be used to create "data transfer" elements, the issue is more
 complex. In the use of parameter names and types in the operational model above, the
 definition of a common vocabulary in the core is justifiable. In the case where data
 transfer elements are being defined, it may be that some types and elements are a
@@ -42,74 +42,47 @@ requirements classes. The mechanism for enforcing this is dependent on the schem
 language.
 
 [[cls-7-2-2]]
-==== Requirements class: UML model extends The Specification
+==== Optional Requirements class: UML model extension to the core
 
-UML is an OMG™ and an ISO standard for expressing object models. If the organizing
-mechanism for the data model used in the specification is an object model, then the
+If the organizing mechanism for the data model used in the standrd is an object model, then the
 mapping from parts of the model to the requirements classes should follow the
 logical mechanism described here.
 
-*#The terminology used here is common to all versions of the UML standard, and may
-be applied to any such version.#*
+The terminology used here is common to all versions of the UML standard, and may
+be applied to any such version.
 
 First, by the requirements above, the extension relationship of this conformance
 test class to the core will be made explicit.
 
+[cols="1,4",width="90%"]
+|===
+2+|*Requirements Class - UML extension to the core* 
+2+|/req/core/data-representation 
+|Target | ModSpec Confromant UML Model
+|Dependency |OGC ModSpec Version 2 (need proper title and document number)
+|REQ028 | /req/core/uml/conformance-with-core 
+|REQ029 | /req/core/uml/object-model 
+|REQ030 | /req/core/uml/dependency-graph 
+|REQ031 | /req/core/uml/leaf-package
+|REQ032 | /req/core/uml/req-class-package
+|REQ033 | /req/core/uml/req-to-leaf
+|REQ034 | /req/core/uml/common-req-classes
+|REQ035 | /req/core/uml/source-target
+|REQ036 | /req/core/uml/leaf-package-dependency
+|REQ037 | /req/core/uml/tw0-way-dependency
+|REQ038 | /req/core/uml/sefregate-into-leaf=packages
+|===
+
+Any conformant UML extension shall comply with the ModSpec Core requirements class.
 [[req-28]]
 [requirement,model=ogc,type="general"]
-====
-#An implementation passing the UML conformance test class shall first pass the core
-conformance test class.#
-====
 
-The things in a UML Structural Model are:
-
-. [[uml-sm-1]]Packages can be contained in one another. A subpackage of a package
-stem:[A] is either stem:[A] or a packages contained in a subpackage of stem:[A]. A
-leaf package is one that contains no subpackages other than itself, but does contain
-classifiers.
-. [[uml-sm-2]]Class or more properly "Classifier" (classes, interfaces, types, data
-types, enumerations, code lists{blank}footnote:[Code list is an ISO TC 211 extension
-to UML.]), are contained in a package or (rarely) another classifier. In all cases,
-they are eventually contained in a package.
-. [[uml-sm-3]]Attribute of a classifier, consisting of a name and a type for its
-value (possibly modified with a cardinality), contained in the classifier.
-. [[uml-sm-4]]Operation, consisting of parameters and a return type, contained in
-its classifier.
-. [[uml-sm-5]]Parameters of an operations consisting of a name and a type for its
-value (just like attributes).
-. [[uml-sm-6]]Return parameters containing the results of the operation, considered
-to be part of the operation (just like the other parameters).
-. [[uml-sm-7]]Associations between classes, consisting of a role name (if it is
-visible from its containing class) and a target type (possibly with cardinality); if
-navigable, the role is considered to be in its source class and dependent on its
-target class; if not navigable, it is neither (a non-navigable role while still part
-of an association, does not affect class implementations. All association must have
-at least one navigable role).
-. [[uml-sm-8]]Constraints, which may be scoped to any of the elements
-<<uml-sm-1>>-<<uml-sm-5>> above. Constraints may be expressed in text, or using a
-symbolic notation (usually but not necessarily OCL).
-
-Packages have dependencies upon one another based on usage. Any of the following conditions will produce a direct package dependency from package stem:[A] to package
-stem:[B]:
-
-. A classifier in stem:[A] uses in its definition a classifier in stem:[B] by using
-it in or as:
-
-.. an explicit dependency relation
-.. the type of an attribute
-.. the target of a navigable association role
-.. the link class of an association that has one of these navigable roles
-.. the key class for a navigable association role
-.. the type of a parameter used in an operation
-.. the return type of an operation
-.. a generalization or realization association
-
-. A subpackage of stem:[A] is dependent on a subpackage of stem:[B].
-
-All of these are statements about the validity of the dependency graph of a UML
-model. Not all UML editors enforce the validity of the dependency graphs of classes
-or packages, so this must be checked separately.
+[width="90%",cols="2,6"]
+|===
+|*REQ028* | */req/core/uml/conformance-with-core * +
+An implementation passing the UML conformance test class _SHALL_ first pass the core
+conformance test class
+|===
 
 Assuming all legitimate direct package dependencies are included in the UML model,
 the conformance/requirements class associated to a package stem:[A] will directly
@@ -118,25 +91,28 @@ if and only if stem:[A] is dependent on stem:[B]. Indirect dependencies will be
 dealt with as the conformance classes cascade.
 
 This clause uses UML terminology, but other object modeling languages and, if
-needed, the object code itself can be mapped to a UML model. An ERA model can be
-considered as a partial Object Oriented Programming model, and can easily be recast
-as UML.
+needed, the object code itself can be mapped to a UML model. 
 
 [[req-29]]
 [requirement,model=ogc,type="general"]
-====
-#To be conformant to this UML conformance class, UML shall be used to express the
+
+[width="90%",cols="2,6"]
+|===
+|*REQ029* | */req/core/uml/object-model* +
+To be conformant to this UML conformance class, UML _SHALL_ be used to express the
 object model, either as the core mechanism of the standard or as a normative adjunct
-to formally explain the standard in a model.#
-====
+to formally explain the standard in a model
+|===
+
 
 [[req-30]]
 [requirement,model=ogc,type="general"]
-====
-#A UML model shall have an explicit dependency graph for the leaf packages and
+|===
+|*REQ030* | * /req/core/uml/dependency-graph* +
+A UML model _SHALL_ have an explicit dependency graph for the leaf packages and
 external packages used by the standard consistent with the way their classifiers use
-those of other packages.#
-====
+those of other packages
+|===
 
 NOTE: External packages having predated the current version of the standard will
 not normally have dependencies to packages within the standard.
@@ -165,8 +141,8 @@ include either directly or by a dependency any requirement associated to any of 
 subpackages.#
 ====
 
-The class definitions are the "requirements" of a UML expressed standard. So the
-logical consequence of the above is to organize requirements modules based on leaf
+The class definitions are the "requirements" of a UML expressed standard. Therefore the
+logical consequence of the above is to organize requirements classes based on leaf
 packages.
 
 [[req-33]]
@@ -179,7 +155,7 @@ and all classes and constraints in those packages.#
 If a requirement uses or refers to elements of more than one package, then one of
 the packages will be called the source of the requirement, and the other targets.
 The requirement with the same source package will always be associated to same
-requirements module and class.
+requirements module and/or class.
 
 [[req-34]]
 [requirement,model=ogc,type="general"]
@@ -195,7 +171,7 @@ for describing the source and target of dependencies between packages. By Clause
 <<req-22>>, only classes in the source requirements class will be affected by the
 requirement.
 
-In UML source and target of dependency relation are defined in such a way that the
+In UML, source and target dependency relations are defined in such a way that the
 source of the relation is dependent on the target of the relation.
 
 [[req-35]]
@@ -207,10 +183,10 @@ extension of the target package's class.#
 ====
 
 This means that the dependency graph of the UML packages parallels in some sense the
-extension diagram of the requirements/conformance classes. If we move all leaf
-packages of the model into "requirements class packages" containing their
-corresponding modeling packages we get a model which satisfies the following
-recommendation: *#Each requirements class in a conformant specification should be
+extension diagram of the requirements/conformance classes. If all leaf
+packages of the model are moved into "requirements class packages" containing their
+corresponding modeling packages the model then satisfies the following
+recommendation: *#Each requirements class in a conformant standard should be
 associated to one and only one UML package (which may contain sub-packages for a
 finer level of structure). If the core requirements class contains only
 recommendations, it may be an exception to this.#*
@@ -249,11 +225,11 @@ package of the original class.
 ====
 
 [[cls-7-2-3]]
-==== Requirements class: XML schema extends The Specification
+==== Requirements class: The XML schema extension to the core
 
-This requirements class covers any specifications which has as one of its purposes
-the introduction of a new XML schema. Such a specification would normally define the
-schema, all of its components and its intended uses.
+This requirements class covers any standard which has as one of its purposes
+the introduction of a new XML schema. Such a standard would normally define the
+schema, all of its components, and its intended uses.
 
 First, by the requirements above, the extension relationship of this conformance
 test class to the core must be made explicit.
@@ -262,7 +238,7 @@ test class to the core must be made explicit.
 [requirement,model=ogc,type="general"]
 ====
 #An implementation passing the XML schema conformance test class shall first pass
-the core specification conformance test class.#
+the ModSpec core conformance test class.#
 ====
 
 [[req-40]]
@@ -272,8 +248,7 @@ the core specification conformance test class.#
 the W3C Recommendation for XML schema.#
 ====
 
-XML Schema is defined by W3C, see <<w3c-sp1>> and <<w3c-sp2>>. Each XML schema file
-(usually *.xsd) carries a target namespace specification, recorded in the
+Each XML schema file (usually *.xsd) carries a target namespace specification, recorded in the
 `targetNamespace` attribute of the `<schema>` element in the XML representation. In
 its implementation, this namespace is represented by a globally unique identifier, a
 URI. All schema components defined with that URI as its namespace designation are
@@ -285,12 +260,7 @@ independent of the choice of strategy if and only if the schemas are in a one to
 correspondence to their namespace. A schema may be dependent on another schema and
 may contain "import" directives that load all such schemas whenever it is loaded.
 
-The strategies used by schema-aware applications using XML schema make the same
-basic assumption, and is not required to reload the contents of a schema document if
-it has already loaded the namespace in any previous process (note the independence
-of this with the schema location also found in many XML schema files). For this
-reason, there must be a one to one correspondence between the schema and its
-namespace URI. When a process loads a schema as defined by its namespace URI
+When a process loads a schema as defined by its namespace URI
 identity, it must always get a linkage to all components in that namespace. If not,
 then at sometime in the future, the process will fail when it finds a reference to
 such a component that it missed. To prevent this sort of failure, when a
@@ -299,14 +269,14 @@ to a schema location (a file) that contains or includes all schema components ha
 the URI as their namespace. This is referred to as the "all-components schema
 document".
 
-So in defining a XML schema (either completely, or partially in a specification) the
+In defining a XML schema (either completely, or partially in a standard) the
 fundamental component or module of XML schema is always the namespace and its
 associated schema; which is designated by a URI.
 
 [[req-41]]
 [requirement,model=ogc,type="general"]
 ====
-#If a specification conformant to the XML schema conformance class defines a set of
+#If a standard conformant to the XML schema conformance class defines a set of
 data schemas, all components (e.g. elements, attributes, types ...) associated with
 a single conformance test class shall be scoped to a single XML namespace.#
 ====
@@ -329,14 +299,14 @@ would to have put the schema components for spatial schema and feature schema in
 separate namespaces.
 ====
 
-This is a choice of design, and at the level of this standard, the trade-off factors
+This is a choice of design, and at the level of the ModSpec, the trade-off factors
 cannot be prejudged because the details of such cost-benefit trade-offs are not
 constant. Either of the above approaches may be used.
 
 [[req-43]]
 [requirement,model=ogc,type="general"]
 ====
-#If a specification conformant to the XML schema conformance class defines a direct
+#If a standard conformant to the XML schema conformance class defines a direct
 dependency from one requirement class to another, then a standardization target of
 the corresponding conformance test class shall import a schema that has passed the
 associated conformance test class (dependency) or shall itself pass the associated
@@ -382,17 +352,17 @@ should be referred to as a whole. Subsetting of components in a single XML names
 for conformance purposes is not permitted.
 
 [[cls-7-2-4]]
-==== Requirements class: Schematron extends XML schema
+==== Requirements class: Schematron extension to the ModSpec Core
 
 Schematron (<<iso19757-3>>) provides a notation with which many constraints on XML
-documents can be expressed. This requirements class covers any specification that
+documents can be expressed. This requirements class covers any standard that
 uses Schematron to create patterns or constrains for an XML Schema. First the schema
 must be defined within the bounds of the XML schema requirements class.
 
 [[req-45]]
 [requirement,model=ogc,type="general"]
 ====
-#A specification passing the Schematron conformance test class shall also define or
+#A standard passing the Schematron conformance test class shall also define or
 reference an XML schema that shall pass the XML schema conformance class from this
 standard.#
 ====
@@ -435,10 +405,10 @@ schema.#
 ====
 
 [[cls-7-2-5]]
-==== Requirements class: XML meta-schema extends The Specification
+==== Requirements class: XML meta-schema extension tothe ModSpec Core
 
-This requirements class covers any specification which has as one of its purposes
-the introduction of a new type of XML schema. Such a specification would normally
+This requirements class covers any standard which has as one of its purposes
+the introduction of a new type of XML schema. Such a standard would normally
 define the characteristics of such schema, how its components are created and its
 intended uses.
 
@@ -448,17 +418,17 @@ test class to the core must be made explicit.
 [[req-51]]
 [requirement,model=ogc,type="general"]
 ====
-#A specification passing the XML meta-schema conformance test class shall first pass
+#A standard passing the XML meta-schema conformance test class shall first pass
 the core specification conformance test class.#
 ====
 
 Since the target specification will be defining requirements for XML schemas, it
-will require that this standard be used.
+will require that the ModSpec be used.
 
 [[req-52]]
 [requirement,model=ogc,type="general"]
 ====
-#A specification passing the XML meta-schema conformance test class shall require
+#A standard passing the XML meta-schema conformance test class shall require
 that its specification targets (XML schema) pass the XML schema conformance class
-from this standard.#
+from the ModSpec.#
 ====


### PR DESCRIPTION
Fixed typos, grammar. 
Made use of "standard" and "specification" consistent The current ModSpec does not use standrd OGC requirements class and requirement templates. ModSpec existed prior to such templates. So I inserted a requirements class example and some requirements examples in a template.